### PR TITLE
add multi keys set operation

### DIFF
--- a/lib/redis_cluster/function/set.rb
+++ b/lib/redis_cluster/function/set.rb
@@ -8,8 +8,8 @@ class RedisCluster
     # see https://redis.io/commands#set. Most of the code are copied from
     # https://github.com/redis/redis-rb/blob/master/lib/redis.rb.
     #
-    # SETTER = [:sadd, :spop, :srem]
-    # GETTER = [:scard, :sismembers, :smembers, :srandmember, :sscan]
+    # SETTER = [:sadd, :spop, :srem, :sdiffstore, :sinterstore, :smove, :sunionstore]
+    # GETTER = [:scard, :sismember, :smembers, :srandmember, :sscan, :sdiff, :sinter, :sunion]
     module Set
 
       # Get the number of members in a set.
@@ -77,6 +77,69 @@ class RedisCluster
       # @return [Array<String>]
       def smembers(key)
         call(key, [:smembers, key], read: true)
+      end
+
+      # Subtract multiple sets.
+      #
+      # @param [String, Array<String>] keys keys pointing to sets to subtract
+      # @return [Array<String>] members in the difference
+      def sdiff(*keys)
+        call(keys, [:sdiff] + keys, read: true)
+      end
+
+      # Subtract multiple sets and store the resulting set in a key.
+      #
+      # @param [String] destination destination key
+      # @param [String, Array<String>] keys keys pointing to sets to subtract
+      # @return [Fixnum] number of elements in the resulting set
+      def sdiffstore(destination, *keys)
+        call(keys, [:sdiffstore, destination] + keys)
+      end
+
+      # Intersect multiple sets.
+      #
+      # @param [String, Array<String>] keys keys pointing to sets to intersect
+      # @return [Array<String>] members in the intersection
+      def sinter(*keys)
+        call(keys, [:sinter] + keys, read: true)
+      end
+
+      # Intersect multiple sets and store the resulting set in a key.
+      #
+      # @param [String] destination destination key
+      # @param [String, Array<String>] keys keys pointing to sets to intersect
+      # @return [Fixnum] number of elements in the resulting set
+      def sinterstore(destination, *keys)
+        call(keys, [:sinterstore, destination] + keys)
+      end
+
+      # Move a member from one set to another.
+      #
+      # @param [String] source source key
+      # @param [String] destination destination key
+      # @param [String] member member to move from `source` to `destination`
+      # @return [Boolean]
+      def smove(source, destination, member)
+        call([source, destination],
+             [:smove, source, destination, member],
+             transform: Redis::Boolify)
+      end
+
+      # Add multiple sets.
+      #
+      # @param [String, Array<String>] keys keys pointing to sets to unify
+      # @return [Array<String>] members in the union
+      def sunion(*keys)
+        call(keys, [:sunion] + keys, read: true)
+      end
+
+      # Add multiple sets and store the resulting set in a key.
+      #
+      # @param [String] destination destination key
+      # @param [String, Array<String>] keys keys pointing to sets to unify
+      # @return [Fixnum] number of elements in the resulting set
+      def sunionstore(destination, *keys)
+        call(keys, [:sunionstore, destination] + keys)
       end
     end
   end

--- a/lib/redis_cluster/function/set.rb
+++ b/lib/redis_cluster/function/set.rb
@@ -93,7 +93,7 @@ class RedisCluster
       # @param [String, Array<String>] keys keys pointing to sets to subtract
       # @return [Fixnum] number of elements in the resulting set
       def sdiffstore(destination, *keys)
-        call(keys, [:sdiffstore, destination] + keys)
+        call([keys, destination], [:sdiffstore, destination] + keys)
       end
 
       # Intersect multiple sets.
@@ -110,7 +110,7 @@ class RedisCluster
       # @param [String, Array<String>] keys keys pointing to sets to intersect
       # @return [Fixnum] number of elements in the resulting set
       def sinterstore(destination, *keys)
-        call(keys, [:sinterstore, destination] + keys)
+        call([keys, destination], [:sinterstore, destination] + keys)
       end
 
       # Move a member from one set to another.
@@ -139,7 +139,7 @@ class RedisCluster
       # @param [String, Array<String>] keys keys pointing to sets to unify
       # @return [Fixnum] number of elements in the resulting set
       def sunionstore(destination, *keys)
-        call(keys, [:sunionstore, destination] + keys)
+        call([keys, destination], [:sunionstore, destination] + keys)
       end
     end
   end

--- a/spec/helper/shared_example_function.rb
+++ b/spec/helper/shared_example_function.rb
@@ -2,11 +2,19 @@
 
 shared_examples 'redis function' do |test_table|
   subject{ FakeRedisCluster.new(redis_result).tap{ |o| o.extend described_class } }
-  let(:key){ :wow }
+  let(:multi_keys){ false }
+  let(:key) { multi_keys ? ['{wow}1', '{wow}2'] : :wow }
   let(:result){ transform&.call(redis_result) || redis_result }
   let(:redis_command){ [method] + args }
   let(:transform){ nil }
-  let(:call_args){ [key, redis_command].tap{ |arg| arg << opts unless opts.empty? }}
+  let(:destination){ nil }
+  let(:call_args) do
+    if destination.nil?
+      [key, redis_command].tap{ |arg| arg << opts unless opts.empty? }
+    else
+      [[key, destination], redis_command].tap{ |arg| arg << opts unless opts.empty? }
+    end
+  end
   let(:opts) do
     {}.tap do |h|
       h[:transform] = transform if transform

--- a/spec/redis_cluster/function/set_spec.rb
+++ b/spec/redis_cluster/function/set_spec.rb
@@ -39,6 +39,49 @@ describe RedisCluster::Function::Set do
       args:          ->{ [key] },
       redis_result:  ->{ ['waw', 'wew'] },
       read:          ->{ true }
+    }, {
+      method:        ->{ :sdiff },
+      key:           ->{ ['{wow}1', '{wow}2'] },
+      args:          ->{ key },
+      redis_result:  ->{ ['wew'] },
+      read:          ->{ true }
+    }, {
+      method:        ->{ :sdiffstore },
+      key:           ->{ ['{wow}1', '{wow}2'] },
+      args:          ->{ ['{wow}3', key].flatten },
+      redis_result:  ->{ 1 },
+      read:          ->{ false }
+    }, {
+      method:        ->{ :sinter },
+      key:           ->{ ['{wow}1', '{wow}2'] },
+      args:          ->{ key },
+      redis_result:  ->{ ['waw'] },
+      read:          ->{ true }
+    }, {
+      method:        ->{ :sinterstore },
+      key:           ->{ ['{wow}1', '{wow}2'] },
+      args:          ->{ ['{wow}3', key].flatten },
+      redis_result:  ->{ 1 },
+      read:          ->{ false }
+    }, {
+      method:        ->{ :smove },
+      key:           ->{ ['{wow}1', '{wow}2'] },
+      args:          ->{ [key, 'waw'].flatten },
+      redis_result:  ->{ 1 },
+      transform:     ->{ Redis::Boolify },
+      read:          ->{ false }
+    }, {
+      method:        ->{ :sunion },
+      key:           ->{ ['{wow}1', '{wow}2'] },
+      args:          ->{ key },
+      redis_result:  ->{ ['waw', 'wew', 'wuw'] },
+      read:          ->{ true }
+    }, {
+      method:        ->{ :sunionstore },
+      key:           ->{ ['{wow}1', '{wow}2'] },
+      args:          ->{ ['{wow}3', key].flatten },
+      redis_result:  ->{ 1 },
+      read:          ->{ false }
     }
   ]
 end

--- a/spec/redis_cluster/function/set_spec.rb
+++ b/spec/redis_cluster/function/set_spec.rb
@@ -41,45 +41,48 @@ describe RedisCluster::Function::Set do
       read:          ->{ true }
     }, {
       method:        ->{ :sdiff },
-      key:           ->{ ['{wow}1', '{wow}2'] },
+      multi_keys:    ->{ true },
       args:          ->{ key },
       redis_result:  ->{ ['wew'] },
       read:          ->{ true }
     }, {
       method:        ->{ :sdiffstore },
-      key:           ->{ ['{wow}1', '{wow}2'] },
-      args:          ->{ ['{wow}3', key].flatten },
+      multi_keys:    ->{ true },
+      destination:   ->{ '{wow}3' },
+      args:          ->{ [destination, key].flatten },
       redis_result:  ->{ 1 },
       read:          ->{ false }
     }, {
       method:        ->{ :sinter },
-      key:           ->{ ['{wow}1', '{wow}2'] },
+      multi_keys:    ->{ true },
       args:          ->{ key },
       redis_result:  ->{ ['waw'] },
       read:          ->{ true }
     }, {
       method:        ->{ :sinterstore },
-      key:           ->{ ['{wow}1', '{wow}2'] },
-      args:          ->{ ['{wow}3', key].flatten },
+      multi_keys:    ->{ true },
+      destination:   ->{ '{wow}3' },
+      args:          ->{ [destination, key].flatten },
       redis_result:  ->{ 1 },
       read:          ->{ false }
     }, {
       method:        ->{ :smove },
-      key:           ->{ ['{wow}1', '{wow}2'] },
+      multi_keys:    ->{ true },
       args:          ->{ [key, 'waw'].flatten },
       redis_result:  ->{ 1 },
       transform:     ->{ Redis::Boolify },
       read:          ->{ false }
     }, {
       method:        ->{ :sunion },
-      key:           ->{ ['{wow}1', '{wow}2'] },
+      multi_keys:    ->{ true },
       args:          ->{ key },
       redis_result:  ->{ ['waw', 'wew', 'wuw'] },
       read:          ->{ true }
     }, {
       method:        ->{ :sunionstore },
-      key:           ->{ ['{wow}1', '{wow}2'] },
-      args:          ->{ ['{wow}3', key].flatten },
+      multi_keys:    ->{ true },
+      destination:   ->{ '{wow}3' },
+      args:          ->{ [destination, key].flatten },
       redis_result:  ->{ 1 },
       read:          ->{ false }
     }


### PR DESCRIPTION
This PR contains implementation of multi keys operation for set data structure. The implemented operation are `sdiff`, `sdiffstore`, `sinter`, `sinterstore`, `smove`, `sunion`, and `sunionstore`.