### PR TITLE
[SRE-850] Exclue slave instance in LOADING state from client candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.0.0 [rc] / 2018-06-07
 - [FEATURE] Middleware support
+- [BUGFIX] Exclue slave instance in LOADING state from client candidate.
 
 ## 0.0.9 / 2017-10-02
 * [BUGFIX] Fix race condition in pipeline

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis-cluster (1.0.0.pre.rc.4)
+    redis-cluster (1.0.0)
       redis (~> 3.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis-cluster (1.0.0.pre.rc.3)
+    redis-cluster (1.0.0.pre.rc.4)
       redis (~> 3.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis-cluster (1.0.0.pre.rc.2)
+    redis-cluster (1.0.0.pre.rc.3)
       redis (~> 3.0)
 
 GEM

--- a/lib/redis_cluster/cluster.rb
+++ b/lib/redis_cluster/cluster.rb
@@ -41,9 +41,9 @@ class RedisCluster
       when :master
         slots[slot].first
       when :slave
-        slots[slot][1..-1].sample || slots[slot].first
+        slots[slot][1..-1].select(&:healthy).sample || slots[slot].first
       when :master_slave
-        slots[slot].sample
+        slots[slot].select(&:healthy).sample
       end
     end
 

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RedisCluster
-  VERSION = '1.0.0-rc.3'
+  VERSION = '1.0.0-rc.4'
 end

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RedisCluster
-  VERSION = '1.0.0-rc.4'
+  VERSION = '1.0.0'
 end

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RedisCluster
-  VERSION = '1.0.0-rc.2'
+  VERSION = '1.0.0-rc.3'
 end


### PR DESCRIPTION
## What
Exclue slave instance in LOADING state from client candidate

## How
`RedisCluster::Client` will mark itself to be in loading state for 60s if call result return a LOADING error from redis. `RedisCluster::Cluster` will exclude any `RedisCluster::Client` in LOADING state from client candidate for user command.

cc: @swallowstalker @NithoAlif @ardfard @yusufemon 