### PR TITLE
[SRE-1843] Fix error when no more healthy seeds

### DIFF
--- a/lib/redis_cluster/cluster.rb
+++ b/lib/redis_cluster/cluster.rb
@@ -4,12 +4,16 @@ require_relative 'client'
 
 class RedisCluster
 
+  # NoHealthySeedError is an error when no more pool / healthy seeds in redis cluster.
+  class NoHealthySeedError < StandardError; end
+
   # Cluster implement redis cluster logic for client.
   class Cluster
     attr_reader :options, :slots, :clients, :replicas, :client_creater
 
     HASH_SLOTS = 16_384
     CROSSSLOT_ERROR = Redis::CommandError.new("CROSSSLOT Keys in request don't hash to the same slot")
+    NO_HEALTHY_SEED_ERROR = NoHealthySeedError.new("No healthy seed")
 
     def initialize(seeds, cluster_opts = {}, &block)
       @options = cluster_opts
@@ -80,11 +84,13 @@ class RedisCluster
       pool = clients.values.select(&:healthy?)
       begin
         try -= 1
-        raise 'No healthy seed' if pool.length.zero?
+        raise NO_HEALTHY_SEED_ERROR if pool.length.zero?
 
         i = rand(pool.length)
         client = pool[i]
         slots_and_clients(client)
+      rescue NoHealthySeedError => e
+        raise e
       rescue StandardError => e
         pool.delete_at(i)
         try.positive? ? retry : (raise e)

--- a/lib/redis_cluster/cluster.rb
+++ b/lib/redis_cluster/cluster.rb
@@ -13,7 +13,7 @@ class RedisCluster
 
     HASH_SLOTS = 16_384
     CROSSSLOT_ERROR = Redis::CommandError.new("CROSSSLOT Keys in request don't hash to the same slot")
-    NO_HEALTHY_SEED_ERROR = NoHealthySeedError.new("No healthy seed")
+    NO_HEALTHY_SEED_ERROR = NoHealthySeedError.new('No healthy seed')
 
     def initialize(seeds, cluster_opts = {}, &block)
       @options = cluster_opts

--- a/spec/redis_cluster/cluster_spec.rb
+++ b/spec/redis_cluster/cluster_spec.rb
@@ -4,7 +4,7 @@ require 'pry'
 
 describe RedisCluster::Cluster do
   subject do
-    described_class.new([url], read_mode: read_mode, force_cluster: force_cluster) do |url|
+    described_class.new(seeds, read_mode: read_mode, force_cluster: force_cluster) do |url|
       host, port = url.split(':', 2)
       RedisCluster::Client.new(host: host, port: port).tap do |cl|
         cl.circuit = circuit
@@ -18,6 +18,7 @@ describe RedisCluster::Cluster do
       allow(circuit).to receive(:failed)
     end
   end
+  let(:seeds){ [url] }
   let(:url){ '127.0.0.1:7001' }
   let(:read_mode){ :master }
   let(:force_cluster){ true }
@@ -165,6 +166,14 @@ describe RedisCluster::Cluster do
       it do
         expect{ subject }.to raise_error('No healthy seed')
       end
+    end
+  end
+
+  context 'empty seeds' do
+    let(:seeds){ [] }
+
+    it do
+      expect{ subject }.to raise_error(RedisCluster::NoHealthySeedError)
     end
   end
 end


### PR DESCRIPTION
There a bug on redis-cluster client when no healthy seed when reset connection to redis-cluster.

The error is:
```
no implicit conversion from nil to integer (TypeError)
from /mothership/vendor/bundle/ruby/2.3.0/bundler/gems/redis-cluster-8875e0b948eb/lib/redis_cluster/cluster.rb:89:in `rescue in reset'
```
It caused by when no healthy seed,  var i on https://github.com/bukalapak/redis-cluster/blob/fix/lib/redis_cluster/cluster.rb#L83-L89 not declared / nil. 