### PR TITLE
[MIS-157] Fix Stuck at CircuitOpen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.1 / 2020-02-18
+- [BUGFIX] Fix stuck at CircuitOpenError when circuit got tripped.
+
 ## 1.1.0 [rc] / 2019-07-03
 - [BUGFIX] Better failover algorithm
 - [FEATURE] Add parameter for circuit breaker. `circuit_threshold` and circuit_interval.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis-cluster (1.1.0.pre.rc.1)
+    redis-cluster (1.1.1)
       redis (~> 3.0)
 
 GEM

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -84,7 +84,7 @@ class RedisCluster
               "fail_count: #{@circuit.fail_count} "\
               "trigger: #{@circuit.trigger} "\
               "current time: #{Time.now} "\
-              "cause: #{@circuit.causes.map{ |e| e.class.name: e.message }.join("\n")}"
+              "cause: #{@circuit.causes.map{ |e| "#{e.class.name}: #{e.message}" }.join("\n")}"
       end
 
       result = Array.new(queue.size)

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -84,7 +84,7 @@ class RedisCluster
               "fail_count: #{@circuit.fail_count} "\
               "trigger: #{@circuit.trigger} "\
               "current time: #{Time.now} "\
-              "cause: #{@circuit.causes.map{ |e| e.class.name }.join("\n")}"
+              "cause: #{@circuit.causes.map{ |e| e.class.name: e.message }.join("\n")}"
       end
 
       result = Array.new(queue.size)

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -100,7 +100,7 @@ class RedisCluster
       end
 
       result
-    rescue LoadingStateError, CircuitOpenError, Redis::BaseConnectionError => e
+    rescue LoadingStateError, Redis::BaseConnectionError => e
       @circuit.failed(e)
       @ready = false if @circuit.open?
 

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RedisCluster
-  VERSION = '1.1.0-rc.1'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
what:
- Remove CircuitOpenError in rescue
- add `e.message` after `e.class.name` when CircuitOpenError raised