### PR TITLE
Revert Using Redis Base Connection Error as RedisCluster Error Base Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 1.2.0 / 2020-06-15
-- [FEATURE] Using `Redis::BaseConnectionError` as `RedisCluter` error base class.
-
 ## 1.1.1 / 2020-02-18
 - [BUGFIX] Fix stuck at CircuitOpenError when circuit got tripped.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis-cluster (1.2.0)
+    redis-cluster (1.1.1)
       redis (~> 3.0)
 
 GEM

--- a/lib/redis-cluster.rb
+++ b/lib/redis-cluster.rb
@@ -105,12 +105,12 @@ class RedisCluster
       raise err if err
 
       transform.call(reply)
-    rescue LoadingStateError, CircuitOpenError => e
-      cluster.reset
-      raise e
     rescue Redis::BaseConnectionError => e
       cluster.reset
       retry if (retries += 1) < 3
+      raise e
+    rescue LoadingStateError, CircuitOpenError => e
+      cluster.reset
       raise e
     end
   end

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -7,10 +7,10 @@ require_relative 'version'
 class RedisCluster
 
   # LoadingStateError is an error when try to read redis that in loading state.
-  class LoadingStateError < Redis::BaseConnectionError; end
+  class LoadingStateError < StandardError; end
 
   # CircuitOpenError is an error that fired when circuit in client is trip.
-  class CircuitOpenError < Redis::BaseConnectionError; end
+  class CircuitOpenError < StandardError; end
 
   # Client is a decorator object for Redis::Client. It add queue to support pipelining and another
   # useful addition
@@ -100,8 +100,6 @@ class RedisCluster
       end
 
       result
-    rescue CircuitOpenError => e
-      raise e
     rescue LoadingStateError, Redis::BaseConnectionError => e
       @circuit.failed(e)
       @ready = false if @circuit.open?

--- a/lib/redis_cluster/cluster.rb
+++ b/lib/redis_cluster/cluster.rb
@@ -5,7 +5,7 @@ require_relative 'client'
 class RedisCluster
 
   # NoHealthySeedError is an error when no more pool / healthy seeds in redis cluster.
-  class NoHealthySeedError < Redis::BaseConnectionError; end
+  class NoHealthySeedError < StandardError; end
 
   # Cluster implement redis cluster logic for client.
   class Cluster

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RedisCluster
-  VERSION = '1.2.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
Revert https://github.com/bukalapak/redis-cluster/pull/16 because it's hard to understand the rescue flow.