### PR TITLE
[MIS-785] Add RedisCluster Error Base Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0 / 2020-06-16
+- [FEATURE] Add RedisCluster error base class.
+
 ## 1.1.1 / 2020-02-18
 - [BUGFIX] Fix stuck at CircuitOpenError when circuit got tripped.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redis-cluster (1.1.1)
+    redis-cluster (1.2.0)
       redis (~> 3.0)
 
 GEM

--- a/lib/redis-cluster.rb
+++ b/lib/redis-cluster.rb
@@ -10,7 +10,6 @@ require_relative 'redis_cluster/future'
 require_relative 'redis_cluster/function'
 require_relative 'redis_cluster/middlewares'
 
-
 # RedisCluster is a client for redis-cluster *huh*
 class RedisCluster
   include MonitorMixin

--- a/lib/redis-cluster.rb
+++ b/lib/redis-cluster.rb
@@ -5,9 +5,11 @@ require 'redis'
 require_relative 'redis_cluster/cluster'
 require_relative 'redis_cluster/client'
 require_relative 'redis_cluster/circuit'
+require_relative 'redis_cluster/error'
 require_relative 'redis_cluster/future'
 require_relative 'redis_cluster/function'
 require_relative 'redis_cluster/middlewares'
+
 
 # RedisCluster is a client for redis-cluster *huh*
 class RedisCluster

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -5,7 +5,6 @@ require 'redis'
 require_relative 'error'
 require_relative 'version'
 
-
 class RedisCluster
 
   # Client is a decorator object for Redis::Client. It add queue to support pipelining and another

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -5,12 +5,14 @@ require 'redis'
 require_relative 'version'
 
 class RedisCluster
+  # Error is a base class for all of RedisCluster error.
+  class Error < StandardError; end
 
   # LoadingStateError is an error when try to read redis that in loading state.
-  class LoadingStateError < StandardError; end
+  class LoadingStateError < Error; end
 
   # CircuitOpenError is an error that fired when circuit in client is trip.
-  class CircuitOpenError < StandardError; end
+  class CircuitOpenError < Error; end
 
   # Client is a decorator object for Redis::Client. It add queue to support pipelining and another
   # useful addition

--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -2,17 +2,11 @@
 
 require 'redis'
 
+require_relative 'error'
 require_relative 'version'
 
+
 class RedisCluster
-  # Error is a base class for all of RedisCluster error.
-  class Error < StandardError; end
-
-  # LoadingStateError is an error when try to read redis that in loading state.
-  class LoadingStateError < Error; end
-
-  # CircuitOpenError is an error that fired when circuit in client is trip.
-  class CircuitOpenError < Error; end
 
   # Client is a decorator object for Redis::Client. It add queue to support pipelining and another
   # useful addition

--- a/lib/redis_cluster/cluster.rb
+++ b/lib/redis_cluster/cluster.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 require_relative 'client'
+require_relative 'error'
 
 class RedisCluster
-
-  # NoHealthySeedError is an error when no more pool / healthy seeds in redis cluster.
-  class NoHealthySeedError < Error; end
 
   # Cluster implement redis cluster logic for client.
   class Cluster

--- a/lib/redis_cluster/cluster.rb
+++ b/lib/redis_cluster/cluster.rb
@@ -5,7 +5,7 @@ require_relative 'client'
 class RedisCluster
 
   # NoHealthySeedError is an error when no more pool / healthy seeds in redis cluster.
-  class NoHealthySeedError < StandardError; end
+  class NoHealthySeedError < Error; end
 
   # Cluster implement redis cluster logic for client.
   class Cluster

--- a/lib/redis_cluster/error.rb
+++ b/lib/redis_cluster/error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RedisCluster
+  # Error is a base class for all of RedisCluster error.
+  class Error < StandardError; end
+
+  # LoadingStateError is an error when try to read redis that in loading state.
+  class LoadingStateError < Error; end
+
+  # CircuitOpenError is an error that fired when circuit in client is trip.
+  class CircuitOpenError < Error; end
+
+  # NoHealthySeedError is an error when no more pool / healthy seeds in redis cluster.
+  class NoHealthySeedError < Error; end
+
+end

--- a/lib/redis_cluster/version.rb
+++ b/lib/redis_cluster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class RedisCluster
-  VERSION = '1.1.1'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
To make client just need to know `RedisCluster::Error` to handle error from this client.